### PR TITLE
fix Cannot read properties of undefined (reading 'ca')

### DIFF
--- a/src/ls/driver.ts
+++ b/src/ls/driver.ts
@@ -30,6 +30,7 @@ export default class VerticaSQL extends AbstractDriver<DriverLib, DriverOptions>
       workload: this.credentials.workload,
     }
 
+    this.credentials.tls = this.credentials.tls || {};
     if (this.credentials.tls['ca']){
       options['tls_trusted_certs'] = this.credentials.tls['ca'].replace(/^file:\/\//, '')
     }


### PR DESCRIPTION
There is an error message "Cannot read properties of undefined (reading 'ca')" when creating a connection and TLS mode is `disable` or `require`.